### PR TITLE
net: wireless: core.c: comment out code CONFIG_ANDROID to avoid kerne…

### DIFF
--- a/net/wireless/core.c
+++ b/net/wireless/core.c
@@ -563,6 +563,7 @@ int wiphy_register(struct wiphy *wiphy)
 				rdev->wiphy.wowlan->pattern_max_len)))
 		return -EINVAL;
 
+#if 0
 #ifdef CONFIG_ANDROID
 	/* use wowlan by default */
 	if (rdev->wiphy.wowlan->flags & WIPHY_WOWLAN_ANY) {
@@ -575,6 +576,7 @@ int wiphy_register(struct wiphy *wiphy)
 		wowlan_cfg->any = true;
 		rdev->wiphy.wowlan_config = wowlan_cfg;
 	}
+#endif
 #endif
 #endif
 	/* check and set up bitrates */


### PR DESCRIPTION
…l panic

kernel panic when using this driver on Andoid Lollilop. To solve the issue, comment
this part out.

In file: net/wireless/core.c, there is one code section wrapped by CONFIG_ANDROID.
If I leave it there and set CONFIG_ANDROID=y in .config, then when insmod wl18xx.ko,
there will be a kernel panic:

[  822.655735] wl18xx_driver wl18xx.0.auto: Direct firmware load for ti-connectivity/wl18xx-conf.bin failed with e2
[  822.666460] wl18xx_driver wl18xx.0.auto: Falling back to user helper
shell@hikey:/ # [  822.680798] wlcore: ERROR could not get configuration binary ti-connectivity/wl18xx-conf.bin: -1
[  822.689709] wlcore: WARNING falling back to default config
[  822.936265] wlcore: wl18xx HW: 183x or 180x, PG 2.2 (ROM 0x11)
[  822.944699] Unable to handle kernel NULL pointer dereference at virtual address 00000000
[  822.952886] pgd = ffffffc000c9b000
[  822.956358] [00000000] *pgd=000000003d808003, *pud=000000003d808003, *pmd=000000003d809003, *pte=00600000f680177
[  822.966779] Internal error: Oops: 96000005 [#1] PREEMPT SMP
[  822.972375] Modules linked in: wl18xx(O) wlcore_sdio(O) wlcore(O) mac80211(O) cfg80211(O) compat(O) mali gator l
[  822.987341] CPU: 0 PID: 813 Comm: kworker/0:1 Tainted: G           O   3.18.0+ #8
[  822.994885] Workqueue: events request_firmware_work_func
[  823.000239] task: ffffffc0359b2100 ti: ffffffc035a7c000 task.ti: ffffffc035a7c000
[  823.007875] PC is at wiphy_register+0x59c/0x70c [cfg80211]
[  823.013511] LR is at ieee80211_register_hw+0x324/0x944 [mac80211]
[  823.019632] pc : [<ffffffbffc283010>] lr : [<ffffffbffc316b78>] pstate: 60000145
[  823.027041] sp : ffffffc035a7fc10
...
...
[  823.386292] Call trace:
[  823.388765] [<ffffffbffc283010>] wiphy_register+0x59c/0x70c [cfg80211]
[  823.395314] [<ffffffbffc316b74>] ieee80211_register_hw+0x320/0x944 [mac80211]
[  823.402460] [<ffffffbffc3c5d10>] wlcore_nvs_cb+0x700/0x920 [wlcore]
[  823.408729] [<ffffffc0004fa010>] request_firmware_work_func+0x30/0x58
[  823.415172] [<ffffffc0000c7018>] process_one_work+0x154/0x414
[  823.420918] [<ffffffc0000c7a80>] worker_thread+0x13c/0x470
[  823.426406] [<ffffffc0000cc1c8>] kthread+0xd8/0xf0
[  823.431199] Code: 9106a000 94f8b3f5 128002a0 17fffed0 (b9400000)
[  823.437315] ---[ end trace 0d983b8703553052 ]---

Signed-off-by: Guodong Xu guodong.xu@linaro.org
